### PR TITLE
fix: apply GPS profile policy when configuration changes

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -6,6 +6,7 @@
 #include "Default.h"
 #include "GPS.h"
 #include "GpioLogic.h"
+#include "GpsProfile.h"
 #include "NodeDB.h"
 #include "PowerMon.h"
 #include "RTC.h"
@@ -865,6 +866,20 @@ bool GPS::setup()
             delay(750); // will cause a receiver restart so wait a bit
             SEND_UBX_PACKET(0x06, 0x8A, _message_VALSET_DISABLE_SBAS_BBR, "disable SBAS M10 GPS BBR", 300);
             delay(750); // will cause a receiver restart so wait a bit
+
+            uint8_t dynamicModel;
+            if (GpsProfile::ubxDynamicModel(config.position.gps_profile, dynamicModel)) {
+                const uint8_t dynamicModelConfig[] = {0x00, 0x03, 0x00, 0x00, 0x21, 0x00, 0x11, 0x20, dynamicModel};
+                clearBuffer();
+                msglen = makeUBXPacket(0x06, 0x8A, sizeof(dynamicModelConfig), dynamicModelConfig);
+                _serial_gps->write(UBXscratch, msglen);
+                if (getACK(0x06, 0x8A, 300) != GNSS_RESPONSE_OK) {
+                    LOG_WARN("Unable to set M10 dynamic model");
+                } else {
+                    LOG_INFO("Set M10 dynamic model for GPS profile %d", config.position.gps_profile);
+                }
+                delay(750);
+            }
 
             // Done with initialization, Now enable wanted NMEA messages in BBR layer so they will survive a periodic
             // sleep.

--- a/src/gps/GpsProfile.h
+++ b/src/gps/GpsProfile.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <climits>
+
+#include "mesh/generated/meshtastic/config.pb.h"
+
+namespace GpsProfile
+{
+inline constexpr uint32_t basePositionFlags()
+{
+    return meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE | meshtastic_Config_PositionConfig_PositionFlags_DOP |
+           meshtastic_Config_PositionConfig_PositionFlags_SATINVIEW | meshtastic_Config_PositionConfig_PositionFlags_TIMESTAMP;
+}
+
+inline void applyFixed(meshtastic_Config_PositionConfig &position)
+{
+    position.gps_update_interval = 1800;
+    position.position_broadcast_secs = 3600;
+    position.broadcast_smart_minimum_interval_secs = INT32_MAX;
+    position.broadcast_smart_minimum_distance = INT32_MAX;
+    position.position_flags = basePositionFlags();
+    position.position_broadcast_smart_enabled = false;
+}
+
+inline bool apply(meshtastic_Config_PositionConfig &position)
+{
+    switch (position.gps_profile) {
+    case meshtastic_Config_PositionConfig_GpsProfile_FIXED_POSITION:
+        applyFixed(position);
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_PEDESTRIAN:
+        position.gps_update_interval = 60;
+        position.position_broadcast_secs = 900;
+        position.broadcast_smart_minimum_interval_secs = 60;
+        position.broadcast_smart_minimum_distance = 50;
+        position.position_flags = basePositionFlags() | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
+                                  meshtastic_Config_PositionConfig_PositionFlags_HEADING;
+        position.position_broadcast_smart_enabled = true;
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_VEHICLE:
+        position.gps_update_interval = 30;
+        position.position_broadcast_secs = 900;
+        position.broadcast_smart_minimum_interval_secs = 120;
+        position.broadcast_smart_minimum_distance = 500;
+        position.position_flags = basePositionFlags() | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
+                                  meshtastic_Config_PositionConfig_PositionFlags_HEADING;
+        position.position_broadcast_smart_enabled = true;
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_AIRBORNE:
+        position.gps_update_interval = 10;
+        position.position_broadcast_secs = 900;
+        position.broadcast_smart_minimum_interval_secs = 60;
+        position.broadcast_smart_minimum_distance = 2000;
+        position.position_flags = basePositionFlags() | meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL |
+                                  meshtastic_Config_PositionConfig_PositionFlags_GEOIDAL_SEPARATION |
+                                  meshtastic_Config_PositionConfig_PositionFlags_SPEED |
+                                  meshtastic_Config_PositionConfig_PositionFlags_HEADING;
+        position.position_broadcast_smart_enabled = true;
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_MANUAL:
+    default:
+        return false;
+    }
+}
+
+inline bool ubxDynamicModel(meshtastic_Config_PositionConfig_GpsProfile profile, uint8_t &dynamicModel)
+{
+    switch (profile) {
+    case meshtastic_Config_PositionConfig_GpsProfile_FIXED_POSITION:
+        dynamicModel = 2;
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_PEDESTRIAN:
+        dynamicModel = 3;
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_VEHICLE:
+        dynamicModel = 4;
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_AIRBORNE:
+        dynamicModel = 7;
+        return true;
+    case meshtastic_Config_PositionConfig_GpsProfile_MANUAL:
+    default:
+        return false;
+    }
+}
+} // namespace GpsProfile

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -1,4 +1,6 @@
 #include "configuration.h"
+
+#include "GpsProfile.h"
 #if !MESHTASTIC_EXCLUDE_GPS
 #include "GPS.h"
 #endif
@@ -765,41 +767,12 @@ void NodeDB::initConfigGPS()
     config.position.position_broadcast_smart_enabled = true;
 #endif
 
-    const uint32_t base_flags =
-        (meshtastic_Config_PositionConfig_PositionFlags_DOP | meshtastic_Config_PositionConfig_PositionFlags_SATINVIEW |
-         meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE);
-
-    if (config.position.gps_profile == meshtastic_Config_PositionConfig_GpsProfile_FIXED_POSITION ||
-        IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
+    if (IS_ONE_OF(config.device.role, meshtastic_Config_DeviceConfig_Role_ROUTER, meshtastic_Config_DeviceConfig_Role_ROUTER_LATE,
                   meshtastic_Config_DeviceConfig_Role_CLIENT_BASE)) {
-        config.position.position_flags = base_flags;
-        config.position.position_broadcast_smart_enabled = false;
-        config.position.position_broadcast_secs = ONE_DAY / 2;
-    } else if (config.position.gps_profile == meshtastic_Config_PositionConfig_GpsProfile_PEDESTRIAN) {
-        config.position.position_flags = (base_flags | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
-                                          meshtastic_Config_PositionConfig_PositionFlags_HEADING);
-        config.position.broadcast_smart_minimum_distance = 50;
-        config.position.broadcast_smart_minimum_interval_secs = 60;
-        config.position.position_broadcast_secs = 900;
-    } else if (config.position.gps_profile == meshtastic_Config_PositionConfig_GpsProfile_VEHICLE) {
-
-        config.position.position_flags = (base_flags | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
-                                          meshtastic_Config_PositionConfig_PositionFlags_HEADING);
-        config.position.broadcast_smart_minimum_distance = 500;
-        config.position.broadcast_smart_minimum_interval_secs = 120;
-        config.position.position_broadcast_secs = 900;
-    } else if (config.position.gps_profile == meshtastic_Config_PositionConfig_GpsProfile_AIRBORNE) {
+        GpsProfile::applyFixed(config.position);
+    } else if (!GpsProfile::apply(config.position)) { // Manual profile retains existing defaults.
         config.position.position_flags =
-            (base_flags | meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL |
-             meshtastic_Config_PositionConfig_PositionFlags_GEOIDAL_SEPARATION |
-             meshtastic_Config_PositionConfig_PositionFlags_SPEED | meshtastic_Config_PositionConfig_PositionFlags_HEADING);
-        config.position.broadcast_smart_minimum_distance = 200;
-        config.position.broadcast_smart_minimum_interval_secs = 60;
-        config.position.position_broadcast_secs = 900;
-
-    } else { // original settings
-        config.position.position_flags =
-            (base_flags | meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL |
+            (GpsProfile::basePositionFlags() | meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL |
              meshtastic_Config_PositionConfig_PositionFlags_SPEED | meshtastic_Config_PositionConfig_PositionFlags_HEADING);
         config.position.broadcast_smart_minimum_distance = 100;
         config.position.broadcast_smart_minimum_interval_secs = 30;

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -233,7 +233,7 @@ class NodeDB
      */
     size_t getNumOnlineMeshNodes(bool localOnly = false);
 
-    void initConfigIntervals(), initModuleConfigIntervals(), resetNodes(bool keepFavorites = false),
+    void initConfigIntervals(), initConfigGPS(), initModuleConfigIntervals(), resetNodes(bool keepFavorites = false),
         removeNodeByNum(NodeNum nodeNum);
 
     bool factoryReset(bool eraseBleBonds = false);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include "Default.h"
+#include "GpsProfile.h"
 #include "TypeConversions.h"
 
 #if !MESHTASTIC_EXCLUDE_MQTT
@@ -671,6 +672,9 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c)
             saveChanges(SEGMENT_NODEDATABASE | SEGMENT_CONFIG, false);
         }
         config.position = c.payload_variant.position;
+        if (GpsProfile::apply(config.position)) {
+            LOG_INFO("Applied GPS profile %d", config.position.gps_profile);
+        }
 
         // Save nodedb as well in case we got a fixed position packet
         break;

--- a/test/test_gps_profile/test_main.cpp
+++ b/test/test_gps_profile/test_main.cpp
@@ -1,0 +1,132 @@
+#include "GpsProfile.h"
+#include "TestUtil.h"
+
+#include <climits>
+#include <unity.h>
+
+namespace
+{
+constexpr uint32_t kBaseFlags =
+    meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE | meshtastic_Config_PositionConfig_PositionFlags_DOP |
+    meshtastic_Config_PositionConfig_PositionFlags_SATINVIEW | meshtastic_Config_PositionConfig_PositionFlags_TIMESTAMP;
+
+meshtastic_Config_PositionConfig positionWithSentinelValues()
+{
+    meshtastic_Config_PositionConfig position = {};
+    position.gps_update_interval = 321;
+    position.position_broadcast_secs = 654;
+    position.broadcast_smart_minimum_interval_secs = 987;
+    position.broadcast_smart_minimum_distance = 1234;
+    position.position_flags = meshtastic_Config_PositionConfig_PositionFlags_HVDOP;
+    position.position_broadcast_smart_enabled = false;
+    return position;
+}
+} // namespace
+
+void test_manual_profile_preserves_existing_position_settings()
+{
+    auto position = positionWithSentinelValues();
+    position.gps_profile = meshtastic_Config_PositionConfig_GpsProfile_MANUAL;
+
+    TEST_ASSERT_FALSE(GpsProfile::apply(position));
+    TEST_ASSERT_EQUAL_UINT32(321, position.gps_update_interval);
+    TEST_ASSERT_EQUAL_UINT32(654, position.position_broadcast_secs);
+    TEST_ASSERT_EQUAL_UINT32(987, position.broadcast_smart_minimum_interval_secs);
+    TEST_ASSERT_EQUAL_UINT32(1234, position.broadcast_smart_minimum_distance);
+    TEST_ASSERT_EQUAL_UINT32(meshtastic_Config_PositionConfig_PositionFlags_HVDOP, position.position_flags);
+    TEST_ASSERT_FALSE(position.position_broadcast_smart_enabled);
+}
+
+void test_vehicle_profile_uses_documented_policy()
+{
+    auto position = positionWithSentinelValues();
+    position.gps_profile = meshtastic_Config_PositionConfig_GpsProfile_VEHICLE;
+
+    TEST_ASSERT_TRUE(GpsProfile::apply(position));
+    TEST_ASSERT_EQUAL_UINT32(30, position.gps_update_interval);
+    TEST_ASSERT_EQUAL_UINT32(900, position.position_broadcast_secs);
+    TEST_ASSERT_EQUAL_UINT32(120, position.broadcast_smart_minimum_interval_secs);
+    TEST_ASSERT_EQUAL_UINT32(500, position.broadcast_smart_minimum_distance);
+    TEST_ASSERT_EQUAL_UINT32(kBaseFlags | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
+                                 meshtastic_Config_PositionConfig_PositionFlags_HEADING,
+                             position.position_flags);
+    TEST_ASSERT_TRUE(position.position_broadcast_smart_enabled);
+}
+
+void test_pedestrian_profile_uses_documented_policy()
+{
+    auto position = positionWithSentinelValues();
+    position.gps_profile = meshtastic_Config_PositionConfig_GpsProfile_PEDESTRIAN;
+
+    TEST_ASSERT_TRUE(GpsProfile::apply(position));
+    TEST_ASSERT_EQUAL_UINT32(60, position.gps_update_interval);
+    TEST_ASSERT_EQUAL_UINT32(900, position.position_broadcast_secs);
+    TEST_ASSERT_EQUAL_UINT32(60, position.broadcast_smart_minimum_interval_secs);
+    TEST_ASSERT_EQUAL_UINT32(50, position.broadcast_smart_minimum_distance);
+    TEST_ASSERT_EQUAL_UINT32(kBaseFlags | meshtastic_Config_PositionConfig_PositionFlags_SPEED |
+                                 meshtastic_Config_PositionConfig_PositionFlags_HEADING,
+                             position.position_flags);
+    TEST_ASSERT_TRUE(position.position_broadcast_smart_enabled);
+}
+
+void test_airborne_profile_uses_documented_policy()
+{
+    auto position = positionWithSentinelValues();
+    position.gps_profile = meshtastic_Config_PositionConfig_GpsProfile_AIRBORNE;
+
+    TEST_ASSERT_TRUE(GpsProfile::apply(position));
+    TEST_ASSERT_EQUAL_UINT32(10, position.gps_update_interval);
+    TEST_ASSERT_EQUAL_UINT32(900, position.position_broadcast_secs);
+    TEST_ASSERT_EQUAL_UINT32(60, position.broadcast_smart_minimum_interval_secs);
+    TEST_ASSERT_EQUAL_UINT32(2000, position.broadcast_smart_minimum_distance);
+    TEST_ASSERT_EQUAL_UINT32(kBaseFlags | meshtastic_Config_PositionConfig_PositionFlags_ALTITUDE_MSL |
+                                 meshtastic_Config_PositionConfig_PositionFlags_GEOIDAL_SEPARATION |
+                                 meshtastic_Config_PositionConfig_PositionFlags_SPEED |
+                                 meshtastic_Config_PositionConfig_PositionFlags_HEADING,
+                             position.position_flags);
+    TEST_ASSERT_TRUE(position.position_broadcast_smart_enabled);
+}
+
+void test_fixed_profile_disables_smart_broadcasting()
+{
+    auto position = positionWithSentinelValues();
+    position.gps_profile = meshtastic_Config_PositionConfig_GpsProfile_FIXED_POSITION;
+
+    TEST_ASSERT_TRUE(GpsProfile::apply(position));
+    TEST_ASSERT_EQUAL_UINT32(1800, position.gps_update_interval);
+    TEST_ASSERT_EQUAL_UINT32(3600, position.position_broadcast_secs);
+    TEST_ASSERT_EQUAL_UINT32(INT32_MAX, position.broadcast_smart_minimum_interval_secs);
+    TEST_ASSERT_EQUAL_UINT32(INT32_MAX, position.broadcast_smart_minimum_distance);
+    TEST_ASSERT_EQUAL_UINT32(kBaseFlags, position.position_flags);
+    TEST_ASSERT_FALSE(position.position_broadcast_smart_enabled);
+}
+
+void test_ublox_dynamic_model_matches_profile()
+{
+    uint8_t dynamicModel = 0;
+
+    TEST_ASSERT_TRUE(GpsProfile::ubxDynamicModel(meshtastic_Config_PositionConfig_GpsProfile_FIXED_POSITION, dynamicModel));
+    TEST_ASSERT_EQUAL_UINT8(2, dynamicModel);
+    TEST_ASSERT_TRUE(GpsProfile::ubxDynamicModel(meshtastic_Config_PositionConfig_GpsProfile_PEDESTRIAN, dynamicModel));
+    TEST_ASSERT_EQUAL_UINT8(3, dynamicModel);
+    TEST_ASSERT_TRUE(GpsProfile::ubxDynamicModel(meshtastic_Config_PositionConfig_GpsProfile_VEHICLE, dynamicModel));
+    TEST_ASSERT_EQUAL_UINT8(4, dynamicModel);
+    TEST_ASSERT_TRUE(GpsProfile::ubxDynamicModel(meshtastic_Config_PositionConfig_GpsProfile_AIRBORNE, dynamicModel));
+    TEST_ASSERT_EQUAL_UINT8(7, dynamicModel);
+    TEST_ASSERT_FALSE(GpsProfile::ubxDynamicModel(meshtastic_Config_PositionConfig_GpsProfile_MANUAL, dynamicModel));
+}
+
+void setup()
+{
+    initializeTestEnvironment();
+    UNITY_BEGIN();
+    RUN_TEST(test_manual_profile_preserves_existing_position_settings);
+    RUN_TEST(test_vehicle_profile_uses_documented_policy);
+    RUN_TEST(test_pedestrian_profile_uses_documented_policy);
+    RUN_TEST(test_airborne_profile_uses_documented_policy);
+    RUN_TEST(test_fixed_profile_disables_smart_broadcasting);
+    RUN_TEST(test_ublox_dynamic_model_matches_profile);
+    exit(UNITY_END());
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary
- centralize the GPS profile policy so defaults and Admin `set_config` writes use the same values
- set GPS update intervals, smart-broadcast settings, and the documented Airborne distance
- configure the u-blox M10 dynamic model for Fixed, Pedestrian, Vehicle, and Airborne profiles
- add focused policy and dynamic-model regression tests
- restore the missing `NodeDB::initConfigGPS()` declaration

## Dependency
This is a follow-up to the existing GPS-profile implementation. It intentionally does **not** embed a private protobuf submodule pin or generated bindings. It should land after [meshtastic/protobufs#749](https://github.com/meshtastic/protobufs/pull/749) is rebased onto a compatible protobuf base, then this branch can be rebased and CI will build the complete chain.

## Validation
- `trunk fmt`
- `git diff --check`
- `pio run -e tbeam-s3-core` with the GPS-profile protobuf binding available locally

The production T-Beam bench was recovered to its normal `2.8.0.ad132e9` firmware after BLE OTA-loader transport testing; this change was not left installed on the bench.